### PR TITLE
Fix Error Laravel 11.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=7.1.0",
         "ext-trader": "*",
-        "illuminate/support": "^5.5|^6.0|^7.0|^8.0"
+        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "orchestra/testbench": "3.5.*|4.*|5.*|6.*",


### PR DESCRIPTION
Adding support to the latest versions of the illuminate/support package to fix the dependency conflict error.